### PR TITLE
Add scheduled group voice chat bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,27 @@
 - 😄 Helping Humanity
 - ⚡ Eploring within
 
-<!---
-SudharmaCreators/SudharmaCreators is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Scheduled Player Bot
+
+This repository includes a basic example of a Telegram bot that can start a
+video call in a specific group and play an audio file at a scheduled time.
+
+The `scheduled_player_bot.py` script requires the following Python packages:
+
+- [pyrogram](https://docs.pyrogram.org/)
+- [pytgcalls](https://github.com/pytgcalls/pytgcalls)
+- [apscheduler](https://apscheduler.readthedocs.io/)
+
+Before running the bot, export these environment variables with your own
+Telegram API credentials and configuration:
+
+```bash
+export API_ID=12345
+export API_HASH="your_api_hash"
+export BOT_TOKEN="123456:token"
+export GROUP_ID=-1001234567890  # ID of the group to join
+export AUDIO_FILE="path/to/track.mp3"
+export SCHEDULE_TIME="2024-01-01 12:00"  # YYYY-MM-DD HH:MM
+```
+
+Run the bot with `python scheduled_player_bot.py`.

--- a/scheduled_player_bot.py
+++ b/scheduled_player_bot.py
@@ -1,0 +1,56 @@
+# Scheduled Telegram Voice Chat Bot
+# This script starts a group video chat in a configured group and plays an
+# audio file when the scheduled time is reached.
+#
+# Requirements:
+#   - pyrogram
+#   - pytgcalls
+#   - apscheduler
+# These packages must be installed in your environment. See the README for
+# setup instructions.
+
+import os
+import asyncio
+from datetime import datetime
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from pyrogram import Client
+from pyrogram.raw.functions.phone import CreateGroupCall
+from pytgcalls import PyTgCalls, idle
+from pytgcalls.types.input_stream import AudioPiped
+
+API_ID = int(os.environ.get("API_ID", 0))
+API_HASH = os.environ.get("API_HASH", "")
+BOT_TOKEN = os.environ.get("BOT_TOKEN", "")
+GROUP_ID = int(os.environ.get("GROUP_ID", 0))  # e.g. -1001234567890
+AUDIO_FILE = os.environ.get("AUDIO_FILE", "track.mp3")
+SCHEDULE_TIME = os.environ.get("SCHEDULE_TIME", "2099-01-01 00:00")
+
+app = Client("scheduled_player", api_id=API_ID, api_hash=API_HASH, bot_token=BOT_TOKEN)
+voice = PyTgCalls(app)
+
+async def start_video_chat():
+    """Start group video chat and stream audio."""
+    # Attempt to create the group call if not already present
+    try:
+        await app.invoke(CreateGroupCall(peer=await app.resolve_peer(GROUP_ID), random_id=app.rnd_id()))
+    except Exception:
+        # A call might already exist
+        pass
+
+    # Start streaming the audio file
+    await voice.join_group_call(GROUP_ID, AudioPiped(AUDIO_FILE))
+
+async def main() -> None:
+    scheduler = AsyncIOScheduler()
+    run_time = datetime.strptime(SCHEDULE_TIME, "%Y-%m-%d %H:%M")
+    scheduler.add_job(start_video_chat, "date", run_date=run_time)
+    scheduler.start()
+
+    await app.start()
+    await voice.start()
+    await idle()
+    await app.stop()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `scheduled_player_bot.py` with scheduled video chat example
- update README with instructions on configuring and running the bot

## Testing
- `python -m py_compile scheduled_player_bot.py`
- `python scheduled_player_bot.py` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_684be9ad50448327a493fad0561b5ff2